### PR TITLE
BugFix

### DIFF
--- a/EconomyShop/src/onebone/economyshop/item/ItemDisplayer.php
+++ b/EconomyShop/src/onebone/economyshop/item/ItemDisplayer.php
@@ -67,7 +67,7 @@ class ItemDisplayer{
 
 	public function despawnFrom(Player $player){
 		$pk = new RemoveEntityPacket;
-		$pk->eid = $this->eid;
+		$pk->entityUniqueId = $this->eid;
 		$player->dataPacket($pk);
 	}
 


### PR DESCRIPTION
```
2017-08-08 [16:18:03] [Server thread/CRITICAL]: Неможливо запустити подію 'pocketmine\event\entity\EntityTeleportEvent' до 'EconomyShop v2.0.8-dev2': Argument 1 passed to pocketmine\network\mcpe\protocol\DataPacket::putEntityUniqueId() must be of the type integer, null given, called in Q:\IMPORTANT\PocketMine-MP\src\pocketmine\network\mcpe\protocol\RemoveEntityPacket.php on line 41 на onebone\economyshop\EconomyShop
2017-08-08 [16:18:03] [Server thread/CRITICAL]: TypeError: "Argument 1 passed to pocketmine\network\mcpe\protocol\DataPacket::putEntityUniqueId() must be of the type integer, null given, called in Q:\IMPORTANT\PocketMine-MP\src\pocketmine\network\mcpe\protocol\RemoveEntityPacket.php on line 41" (EXCEPTION) in "src/pocketmine/network/mcpe/protocol/DataPacket" at line 288
```