### PR TITLE
Sold Item Message Replacement Variable Into Array

### DIFF
--- a/EconomySell/src/onebone/economysell/EconomySell.php
+++ b/EconomySell/src/onebone/economysell/EconomySell.php
@@ -368,7 +368,7 @@ class EconomySell extends PluginBase implements Listener{
                 return true;
             }
             $player->getInventory()->removeItem($item);
-            $player->sendMessage($this->getMessage("sold-item", $sell["amount"] ?? $sell[7], $itemname, $sell["cost"] ?? $sell[8]));
+            $player->sendMessage($this->getMessage("sold-item", [$sell["amount"] ?? $sell[7], $itemname, $sell["cost"] ?? $sell[8]]));
             EconomyAPI::getInstance()->addMoney($player, $sell["cost"] ?? $sell[8]);
         }else{
             $player->sendMessage($this->getMessage("no-item", [$itemname]));


### PR DESCRIPTION
This isn't sent as an array. Causes this error,

```
[Server thread/CRITICAL]: Could not pass event 'pocketmine\event\player\PlayerInteractEvent' to 'EconomySell v2.0.7-3': count(): Parameter must be an array or an object that implements Countable on onebone\economysell\EconomySell
[12:32:28] [Server thread/CRITICAL]: ErrorException: "count(): Parameter must be an array or an object that implements Countable" (EXCEPTION) in "EconomySell_v2.0.7-3.phar/src/onebone/economysell/EconomySell" at line 388
```
So yeah... simple PR to fix that. 
