### PR TITLE
Economy API Update + Protocol changes

### DIFF
--- a/EconomyPShop/plugin.yml
+++ b/EconomyPShop/plugin.yml
@@ -1,8 +1,9 @@
 name: EconomyPShop
-version: 2.0.3
+version: 2.0.4
 author: onebone
 main: onebone\economypshop\EconomyPShop
 api: [3.0.0]
+mcpe-protocol: 361
 commands:
  pshop:
   description: Management command for creating/removing PShops

--- a/EconomyPShop/src/onebone/economypshop/item/ItemDisplayer.php
+++ b/EconomyPShop/src/onebone/economypshop/item/ItemDisplayer.php
@@ -25,8 +25,8 @@ use pocketmine\item\Item;
 use pocketmine\level\Level;
 use pocketmine\level\Position;
 use pocketmine\math\Vector3;
-use pocketmine\network\mcpe\protocol\AddItemEntityPacket;
-use pocketmine\network\mcpe\protocol\RemoveEntityPacket;
+use pocketmine\network\mcpe\protocol\AddItemActorPacket as AddItemEntityPacket;
+use pocketmine\network\mcpe\protocol\RemoveActorPacket as RemoveEntityPacket;
 use pocketmine\Player;
 use pocketmine\Server;
 

--- a/EconomyShop/plugin.yml
+++ b/EconomyShop/plugin.yml
@@ -1,9 +1,10 @@
 name: EconomyShop
-version: 2.0.10
+version: 2.0.11
 api: [3.0.0]
 main: onebone\economyshop\EconomyShop
 author: onebone
 depend: [EconomyAPI]
+mcpe-protocol: 361
 
 commands:
  shop:

--- a/EconomyShop/src/onebone/economyshop/item/ItemDisplayer.php
+++ b/EconomyShop/src/onebone/economyshop/item/ItemDisplayer.php
@@ -25,8 +25,8 @@ use pocketmine\item\Item;
 use pocketmine\level\Level;
 use pocketmine\level\Position;
 use pocketmine\math\Vector3;
-use pocketmine\network\mcpe\protocol\AddItemEntityPacket;
-use pocketmine\network\mcpe\protocol\RemoveEntityPacket;
+use pocketmine\network\mcpe\protocol\AddItemActorPacket;
+use pocketmine\network\mcpe\protocol\RemoveActorPacket;
 use pocketmine\Player;
 use pocketmine\Server;
 
@@ -49,7 +49,7 @@ class ItemDisplayer{
     }
 
     public function spawnTo(Player $player){
-        $pk = new AddItemEntityPacket;
+        $pk = new AddItemActorPacket;
         $pk->entityRuntimeId = $this->eid;
         $pk->item = $this->item;
         $position = new Vector3($this->pos->x + 0.5, $this->pos->y, $this->pos->z + 0.5);
@@ -66,7 +66,7 @@ class ItemDisplayer{
     }
 
     public function despawnFrom(Player $player){
-        $pk = new RemoveEntityPacket;
+        $pk = new RemoveActorPacket;
         $pk->entityUniqueId = $this->eid;
         $player->dataPacket($pk);
     }

--- a/EconomyShop/src/onebone/economyshop/item/ItemDisplayer.php
+++ b/EconomyShop/src/onebone/economyshop/item/ItemDisplayer.php
@@ -25,8 +25,8 @@ use pocketmine\item\Item;
 use pocketmine\level\Level;
 use pocketmine\level\Position;
 use pocketmine\math\Vector3;
-use pocketmine\network\mcpe\protocol\AddItemActorPacket;
-use pocketmine\network\mcpe\protocol\RemoveActorPacket;
+use pocketmine\network\mcpe\protocol\AddItemActorPacket as AddItemEntityPacket;
+use pocketmine\network\mcpe\protocol\RemoveActorPacket as RemoveEntityPacket;
 use pocketmine\Player;
 use pocketmine\Server;
 
@@ -49,7 +49,7 @@ class ItemDisplayer{
     }
 
     public function spawnTo(Player $player){
-        $pk = new AddItemActorPacket;
+        $pk = new AddItemEntityPacket;
         $pk->entityRuntimeId = $this->eid;
         $pk->item = $this->item;
         $position = new Vector3($this->pos->x + 0.5, $this->pos->y, $this->pos->z + 0.5);
@@ -66,7 +66,7 @@ class ItemDisplayer{
     }
 
     public function despawnFrom(Player $player){
-        $pk = new RemoveActorPacket;
+        $pk = new RemoveEntityPacket;
         $pk->entityUniqueId = $this->eid;
         $player->dataPacket($pk);
     }


### PR DESCRIPTION
This PR updates some EconomyAPI plugins, which needed updating.
Along with this, I have also added mcpe-protocol to plugin.yml - To dedicate support to the economy plugins that can't afford to be compatible with lower protocol versions.
This also fixes, and changes the namespaces for the pocketmine-API 3.9.0 update.
Thank you, and I hope you merge these changes soon!