### PR TITLE
Use PM API for player gamertag verification

### DIFF
--- a/EconomyLand/src/onebone/economyland/EconomyLand.php
+++ b/EconomyLand/src/onebone/economyland/EconomyLand.php
@@ -452,7 +452,7 @@ class EconomyLand extends PluginBase implements Listener{
 						$sender->sendMessage($this->getMessage("not-your-land", array($landnum, "%2", "%3")));
 						return true;
 					}else{
-						if(preg_match('#^[a-zA-Z0-9_]{3,16}$#', $player) == 0){
+						if(!Player::isValidUserName($player)){
 							$sender->sendMessage($this->getMessage("invalid-invitee", [$player, "%2", "%3"]));
 							return true;
 						}


### PR DESCRIPTION
Doing this gives you the flexibility to adapt to future gamertag specifications changes.

For example, you will be able to use a gamertag with a blank.